### PR TITLE
Update the load_data method of the database readers

### DIFF
--- a/test/test_databases/test_apnea_ecg.py
+++ b/test/test_databases/test_apnea_ecg.py
@@ -68,6 +68,8 @@ class TestApneaECG:
             0, leads=0, data_format="flat", sampfrom=1000, sampto=2000
         )
         assert data.shape == (1000,)
+        data, data_fs = reader.load_data(0, fs=100, return_fs=True)
+        assert data_fs == 100
 
     def test_load_ecg_data(self):
         rec = reader.ecg_records[0]

--- a/test/test_databases/test_cachet_cadb.py
+++ b/test/test_databases/test_cachet_cadb.py
@@ -66,6 +66,8 @@ class TestCACHET_CADB:
             data_1 = reader.load_data(rec, sampfrom=1000, sampto=5000)
             assert data_1.shape[1] == 4000
             assert np.allclose(data_1, data[:, 1000:5000])
+            data_1, data_1_fs = reader.load_data(rec, fs=2 * reader.fs, return_fs=True)
+            assert data_1_fs == 2 * reader.fs
 
         with pytest.raises(ValueError, match="Invalid `data_format`: xxx"):
             reader.load_data(0, data_format="xxx")

--- a/test/test_databases/test_cachet_cadb.py
+++ b/test/test_databases/test_cachet_cadb.py
@@ -55,19 +55,26 @@ class TestCACHET_CADB:
         assert len(reader) == 2
 
     def test_load_data(self):
+        # reader.fs is 1024
         for rec in reader:
-            data = reader.load_data(rec)
-            data_1 = reader.load_data(rec, data_format="flat", units="μV")
+            data = reader.load_data(rec, sampfrom=0, sampto=6000)
+            data_1 = reader.load_data(
+                rec, data_format="flat", units="μV", sampfrom=0, sampto=6000
+            )
             assert data.ndim == 2 and data.shape[0] == 1
             assert data_1.ndim == 1 and data_1.shape[0] == data.shape[1]
             assert np.allclose(data, data_1.reshape(1, -1) / 1000, atol=1e-2)
-            data_1 = reader.load_data(rec, data_format="flat", fs=2 * reader.fs)
-            assert data_1.shape[0] == 2 * data.shape[1]
+            data_1 = reader.load_data(
+                rec, data_format="flat", sampfrom=1000, sampto=5000, fs=2 * reader.fs
+            )
+            assert data_1.shape[0] == 2 * 4000
             data_1 = reader.load_data(rec, sampfrom=1000, sampto=5000)
             assert data_1.shape[1] == 4000
             assert np.allclose(data_1, data[:, 1000:5000])
-            data_1, data_1_fs = reader.load_data(rec, fs=2 * reader.fs, return_fs=True)
-            assert data_1_fs == 2 * reader.fs
+            data_1, data_1_fs = reader.load_data(
+                rec, sampfrom=1000, sampto=5000, fs=reader.fs // 4, return_fs=True
+            )
+            assert data_1_fs == reader.fs // 4
 
         with pytest.raises(ValueError, match="Invalid `data_format`: xxx"):
             reader.load_data(0, data_format="xxx")

--- a/test/test_databases/test_cinc2018.py
+++ b/test/test_databases/test_cinc2018.py
@@ -152,6 +152,8 @@ class TestCINC2018:
         )
         assert isinstance(data, np.ndarray)
         assert data.shape == (80000,)
+        data, data_fs = reader.load_data(0, fs=100, return_fs=True)
+        assert data_fs == 100
 
     def test_load_ecg_data(self):
         # alias of `load_data`

--- a/test/test_databases/test_cinc2020.py
+++ b/test/test_databases/test_cinc2020.py
@@ -83,6 +83,8 @@ class TestCINC2020:
             assert data_1.shape[1] == 2 * data.shape[1]
             data_1 = reader.load_data(rec, backend="scipy")
             assert np.allclose(data_1, data)
+            data_1, data_1_fs = reader.load_data(rec, fs=300, return_fs=True)
+            assert data_1_fs == 300
 
         with pytest.raises(AssertionError, match="Invalid data_format: `flat`"):
             reader.load_data(rec, data_format="flat")

--- a/test/test_databases/test_cinc2021.py
+++ b/test/test_databases/test_cinc2021.py
@@ -94,6 +94,8 @@ class TestCINC2021:
             assert data_1.shape[1] == 2 * data.shape[1]
             data_1 = reader.load_data(rec, backend="scipy")
             assert np.allclose(data_1, data)
+            data_1, data_1_fs = reader.load_data(rec, fs=300, return_fs=True)
+            assert data_1_fs == 300
 
         reader.load_data(0, leads=2)
         reader.load_data(0, leads="aVR")

--- a/test/test_databases/test_cpsc2018.py
+++ b/test/test_databases/test_cpsc2018.py
@@ -64,6 +64,8 @@ class TestCPSC2018:
             assert np.allclose(data_1, data * 1000)
             data_1 = reader.load_data(rec, data_format="lead_last")
             assert data.shape == data_1.T.shape
+            data, data_fs = reader.load_data(rec, return_fs=True)
+            assert data_fs == reader.fs
         reader.load_data(0)
 
     def test_load_ann(self):

--- a/test/test_databases/test_cpsc2019.py
+++ b/test/test_databases/test_cpsc2019.py
@@ -65,6 +65,8 @@ class TestCPSC2019:
         assert np.allclose(data, data_1.reshape(1, -1) / 1000, atol=1e-2)
         data_1 = reader.load_data(0, data_format="flat", fs=2 * reader.fs)
         assert data_1.shape[0] == 2 * data.shape[1]
+        data_1, data_1_fs = reader.load_data(0, fs=2 * reader.fs, return_fs=True)
+        assert data_1_fs == 2 * reader.fs
 
         with pytest.raises(ValueError, match="Invalid `data_format`: xxx"):
             reader.load_data(0, data_format="xxx")

--- a/test/test_databases/test_cpsc2020.py
+++ b/test/test_databases/test_cpsc2020.py
@@ -68,6 +68,8 @@ class TestCPSC2020:
         assert np.allclose(data_1, data_2[:, 0])
         assert np.allclose(data_1, data_3 / 1000, atol=1e-2)
         assert data_4.shape == (1, 4000)
+        data, data_fs = reader.load_data(0, fs=reader.fs * 2, return_fs=True)
+        assert data_fs == reader.fs * 2
 
         with pytest.raises(ValueError, match="Invalid `data_format`"):
             reader.load_data(0, data_format="invalid")

--- a/test/test_databases/test_cpsc2020.py
+++ b/test/test_databases/test_cpsc2020.py
@@ -57,6 +57,7 @@ class TestCPSC2020:
             CPSC2020(_CWD, subsample=-0.1)
 
     def test_load_data(self):
+        # reader.fs is 400
         data_1 = reader.load_data(0, sampfrom=2000, sampto=4000, data_format="flat")
         data_2 = reader.load_data(
             0, sampfrom=2000, sampto=4000, data_format="channel_last"
@@ -68,8 +69,10 @@ class TestCPSC2020:
         assert np.allclose(data_1, data_2[:, 0])
         assert np.allclose(data_1, data_3 / 1000, atol=1e-2)
         assert data_4.shape == (1, 4000)
-        data, data_fs = reader.load_data(0, fs=reader.fs * 2, return_fs=True)
-        assert data_fs == reader.fs * 2
+        data, data_fs = reader.load_data(
+            0, sampfrom=2000, sampto=4000, fs=reader.fs // 4, return_fs=True
+        )
+        assert data_fs == reader.fs // 4
 
         with pytest.raises(ValueError, match="Invalid `data_format`"):
             reader.load_data(0, data_format="invalid")

--- a/test/test_databases/test_ltafdb.py
+++ b/test/test_databases/test_ltafdb.py
@@ -68,9 +68,8 @@ class TestLTAFDB:
         )
         assert data.shape == (1000,)
         data = reader.load_data(rec)
-        data_1, data_1_fs = reader.load_data(rec, fs=2 * reader.fs, return_fs=True)
-        assert data_1_fs == 2 * reader.fs
-        assert data_1.shape[1] == data.shape[1] * 2
+        data, data_fs = reader.load_data(rec, fs=100, return_fs=True)
+        assert data_fs == 100
 
     def test_load_ann(self):
         ann = reader.load_ann(0)

--- a/test/test_databases/test_ltafdb.py
+++ b/test/test_databases/test_ltafdb.py
@@ -67,6 +67,10 @@ class TestLTAFDB:
             rec, leads=[0], data_format="flat", sampfrom=1000, sampto=2000
         )
         assert data.shape == (1000,)
+        data = reader.load_data(rec)
+        data_1, data_1_fs = reader.load_data(rec, fs=2 * reader.fs, return_fs=True)
+        assert data_1_fs == 2 * reader.fs
+        assert data_1.shape[1] == data.shape[1] * 2
 
     def test_load_ann(self):
         ann = reader.load_ann(0)

--- a/test/test_databases/test_shhs.py
+++ b/test/test_databases/test_shhs.py
@@ -111,7 +111,9 @@ class TestSHHS:
         assert fs_1 == fs
         assert data_1.shape[0] == int(10 * fs)
         assert np.allclose(data_1, data[0, int(10 * fs) : int(20 * fs)])
-        data_1 = reader.load_data(0, return_fs=False)
+        data_1 = reader.load_data(
+            0, sampfrom=10, sampto=20, data_format="flat", return_fs=False
+        )
         assert isinstance(data_1, np.ndarray) and np.allclose(data_1, data)
 
         data_2, _ = reader.load_data(

--- a/test/test_databases/test_shhs.py
+++ b/test/test_databases/test_shhs.py
@@ -111,6 +111,8 @@ class TestSHHS:
         assert fs_1 == fs
         assert data_1.shape[0] == int(10 * fs)
         assert np.allclose(data_1, data[0, int(10 * fs) : int(20 * fs)])
+        data_1 = reader.load_data(0, return_fs=False)
+        assert isinstance(data_1, np.ndarray) and np.allclose(data_1, data)
 
         data_2, _ = reader.load_data(
             0, sampfrom=10, sampto=20, data_format="flat", units="uv"
@@ -131,6 +133,8 @@ class TestSHHS:
         data, fs = reader.load_data(0)
         data_1, fs_1 = reader.load_ecg_data(0)
         assert np.allclose(data, data_1)
+        data_1 = reader.load_ecg_data(0, return_fs=False)
+        assert isinstance(data_1, np.ndarray) and np.allclose(data_1, data)
 
     def test_load_ann(self):
         rec = reader.rec_with_event_ann[0]

--- a/test/test_databases/test_shhs.py
+++ b/test/test_databases/test_shhs.py
@@ -114,8 +114,7 @@ class TestSHHS:
         data_1 = reader.load_data(
             0, sampfrom=10, sampto=20, data_format="flat", return_fs=False
         )
-        assert isinstance(data_1, np.ndarray) and np.allclose(data_1, data)
-
+        assert isinstance(data_1, np.ndarray)
         data_2, _ = reader.load_data(
             0, sampfrom=10, sampto=20, data_format="flat", units="uv"
         )

--- a/test/test_databases/test_sph.py
+++ b/test/test_databases/test_sph.py
@@ -70,6 +70,8 @@ class TestSPH:
             assert np.allclose(data_1, data * 1000)
             data_1 = reader.load_data(rec, data_format="lead_last")
             assert data.shape == data_1.T.shape
+            data_1, data_1_fs = reader.load_data(rec, return_fs=True)
+            assert data_1_fs == reader.fs
 
         with pytest.raises(AssertionError, match="Invalid data_format: `flat`"):
             reader.load_data(rec, data_format="flat")

--- a/torch_ecg/databases/base.py
+++ b/torch_ecg/databases/base.py
@@ -672,6 +672,7 @@ class PhysioNetDataBase(_DataBase):
             with given `units` and `data_format`.
         data_fs : numbers.Real, optional
             Sampling frequency of the output signal.
+            Returned if `return_fs` is True.
 
         """
         fp = str(self.get_absolute_path(rec))

--- a/torch_ecg/databases/base.py
+++ b/torch_ecg/databases/base.py
@@ -27,7 +27,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from string import punctuation
-from typing import Any, List, Optional, Union, Sequence, Dict
+from typing import Any, List, Optional, Union, Sequence, Dict, Tuple
 from numbers import Real
 
 import numpy as np
@@ -632,9 +632,9 @@ class PhysioNetDataBase(_DataBase):
         data_format: str = "channel_first",
         units: Union[str, type(None)] = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
-        """
-        Load physical (converted from digital) ECG data,
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
+        """Load physical (converted from digital) ECG data,
         which is more understandable for humans;
         or load digital signal directly.
 
@@ -659,14 +659,19 @@ class PhysioNetDataBase(_DataBase):
             None for digital data, without digital-to-physical conversion.
         fs : numbers.Real, optional
             Sampling frequency of the output signal.
-            If not None, the loaded data will be resampled to this frequency,
+            If not None, the loaded data will be resampled to this frequency;
+            if None, `self.fs` will be used if available and not None;
             otherwise, the original sampling frequency will be used.
+        return_fs : bool, default False
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
-        numpy.ndarray
+        data : numpy.ndarray
             The ECG data loaded from the record,
             with given `units` and `data_format`.
+        data_fs : numbers.Real, optional
+            Sampling frequency of the output signal.
 
         """
         fp = str(self.get_absolute_path(rec))
@@ -721,14 +726,24 @@ class PhysioNetDataBase(_DataBase):
         elif units.lower() in ["μv", "uv", "muv"]:
             data = 1000 * wfdb_rec.p_signal
 
-        if fs is not None and hasattr(self, "fs") and fs != self.fs:
-            data = SS.resample_poly(data, fs, self.fs, axis=0).astype(data.dtype)
+        if fs is not None:
+            data_fs = fs
+        elif hasattr(self, "fs"):
+            data_fs = self.fs
+        else:
+            data_fs = wfdb_rec.fs
+        if data_fs != wfdb_rec.fs:
+            data = SS.resample_poly(data, data_fs, wfdb_rec.fs, axis=0).astype(
+                data.dtype
+            )
 
         if data_format.lower() in ["channel_first", "lead_first"]:
             data = data.T
         elif data_format.lower() in ["flat", "plain"]:
             data = data.flatten()
 
+        if return_fs:
+            return data, data_fs
         return data
 
     def helper(self, items: Union[List[str], str, type(None)] = None) -> None:

--- a/torch_ecg/databases/cpsc_databases/cpsc2018.py
+++ b/torch_ecg/databases/cpsc_databases/cpsc2018.py
@@ -2,8 +2,9 @@
 
 import re
 import warnings
+from numbers import Real
 from pathlib import Path
-from typing import Any, List, Optional, Union, Sequence
+from typing import Any, List, Optional, Union, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -274,7 +275,8 @@ class CPSC2018(CPSCDataBase):
         leads: Optional[Union[str, int, Sequence[Union[str, int]]]] = None,
         data_format="channel_first",
         units: str = "mV",
-    ) -> np.ndarray:
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         """Load the ECG data of a record.
 
         Parameters
@@ -289,11 +291,15 @@ class CPSC2018(CPSCDataBase):
         units : str, default "mV"
             Units of the output signal, can also be "μV" (with an alias "uV"),
             case insensitive.
+        return_fs : bool, default False
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
         data : numpy.ndarray
             The loaded ECG data.
+        data_fs : numbers.Real, optional
+            Sampling frequency of the output signal.
 
         """
         if isinstance(rec, int):
@@ -327,6 +333,8 @@ class CPSC2018(CPSCDataBase):
         ):
             data *= 1000
 
+        if return_fs:
+            return data, self.fs
         return data
 
     def load_ann(self, rec: Union[str, int], ann_format: str = "n") -> List[str]:

--- a/torch_ecg/databases/cpsc_databases/cpsc2018.py
+++ b/torch_ecg/databases/cpsc_databases/cpsc2018.py
@@ -300,6 +300,7 @@ class CPSC2018(CPSCDataBase):
             The loaded ECG data.
         data_fs : numbers.Real, optional
             Sampling frequency of the output signal.
+            Returned if `return_fs` is True.
 
         """
         if isinstance(rec, int):

--- a/torch_ecg/databases/cpsc_databases/cpsc2019.py
+++ b/torch_ecg/databases/cpsc_databases/cpsc2019.py
@@ -3,7 +3,7 @@
 import json
 from numbers import Real
 from pathlib import Path
-from typing import Any, Optional, Sequence, Union, List
+from typing import Any, Optional, Sequence, Union, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -233,7 +233,8 @@ class CPSC2019(CPSCDataBase):
         data_format: str = "channel_first",
         units: str = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         """Load the ECG data of the record `rec`.
 
         Parameters
@@ -250,17 +251,24 @@ class CPSC2019(CPSCDataBase):
         fs : numbers.Real, optional
             If provided, the loaded data will be resampled to this frequency,
             otherwise the original sampling frequency will be used.
+        return_fs : bool, default False
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
         data : numpy.ndarray,
             The loaded ECG data.
+        data_fs : numbers.Real, optional
+            Sampling frequency of the output signal.
 
         """
         fp = self.get_absolute_path(rec, self.rec_ext)
         data = loadmat(str(fp))["ecg"].astype(DEFAULTS.DTYPE.NP)
         if fs is not None and fs != self.fs:
             data = SS.resample_poly(data, fs, self.fs, axis=0).astype(data.dtype)
+            data_fs = fs
+        else:
+            data_fs = self.fs
         if data_format.lower() in ["channel_first", "lead_first"]:
             data = data.T
         elif data_format.lower() in ["flat", "plain"]:
@@ -271,6 +279,9 @@ class CPSC2019(CPSCDataBase):
             data = (1000 * data).astype(int)
         elif units.lower() != "mv":
             raise ValueError(f"Invalid `units`: {units}")
+
+        if return_fs:
+            return data, data_fs
         return data
 
     def load_ann(self, rec: Union[int, str]) -> np.ndarray:

--- a/torch_ecg/databases/cpsc_databases/cpsc2019.py
+++ b/torch_ecg/databases/cpsc_databases/cpsc2019.py
@@ -260,6 +260,7 @@ class CPSC2019(CPSCDataBase):
             The loaded ECG data.
         data_fs : numbers.Real, optional
             Sampling frequency of the output signal.
+            Returned if `return_fs` is True.
 
         """
         fp = self.get_absolute_path(rec, self.rec_ext)

--- a/torch_ecg/databases/cpsc_databases/cpsc2020.py
+++ b/torch_ecg/databases/cpsc_databases/cpsc2020.py
@@ -391,7 +391,8 @@ class CPSC2020(CPSCDataBase):
         data_format: str = "channel_first",
         units: str = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         """Load the ECG data of the record `rec`.
 
         Parameters
@@ -414,11 +415,15 @@ class CPSC2020(CPSCDataBase):
             Frequency of the output signal.
             if not None, the loaded data will be resampled to this frequency;
             if None, the loaded data will be returned as is.
+        return_fs : bool, default False
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
         data : numpy.ndarray
             The loaded ECG data.
+        data_fs : numbers.Real, optional
+            Sampling frequency of the output signal.
 
         """
         rec_fp = self.get_absolute_path(rec, self.rec_ext)
@@ -427,6 +432,9 @@ class CPSC2020(CPSCDataBase):
         data = data[sf:st]
         if fs is not None and fs != self.fs:
             data = SS.resample_poly(data, fs, self.fs, axis=0).astype(data.dtype)
+            data_fs = fs
+        else:
+            data_fs = self.fs
         if data_format.lower() in ["channel_first", "lead_first"]:
             data = data.T
         elif data_format.lower() in ["flat", "plain"]:
@@ -437,6 +445,9 @@ class CPSC2020(CPSCDataBase):
             data = (1000 * data).astype(int)
         elif units.lower() != "mv":
             raise ValueError(f"Invalid `units`: {units}")
+
+        if return_fs:
+            return data, data_fs
         return data
 
     def load_ann(

--- a/torch_ecg/databases/cpsc_databases/cpsc2020.py
+++ b/torch_ecg/databases/cpsc_databases/cpsc2020.py
@@ -424,6 +424,7 @@ class CPSC2020(CPSCDataBase):
             The loaded ECG data.
         data_fs : numbers.Real, optional
             Sampling frequency of the output signal.
+            Returned if `return_fs` is True.
 
         """
         rec_fp = self.get_absolute_path(rec, self.rec_ext)

--- a/torch_ecg/databases/nsrr_databases/shhs.py
+++ b/torch_ecg/databases/nsrr_databases/shhs.py
@@ -1067,6 +1067,7 @@ class SHHS(NSRRDataBase, PSGDataBaseMixin):
             The loaded ECG data.
         data_fs : numbers.Real
             Sampling frequency of the loaded ECG data.
+            Returned if `return_fs` is True.
 
         """
         allowed_data_format = [

--- a/torch_ecg/databases/nsrr_databases/shhs.py
+++ b/torch_ecg/databases/nsrr_databases/shhs.py
@@ -1030,7 +1030,8 @@ class SHHS(NSRRDataBase, PSGDataBaseMixin):
         data_format: str = "channel_first",
         units: Union[str, type(None)] = "mV",
         fs: Optional[int] = None,
-    ) -> Tuple[np.ndarray, Real]:
+        return_fs: bool = True,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         """Load ECG data of the record.
 
         Parameters
@@ -1057,6 +1058,8 @@ class SHHS(NSRRDataBase, PSGDataBaseMixin):
             Sampling frequency of the loaded data.
             If not None, the loaded data will be resampled to this frequency,
             otherwise, the original sampling frequency will be used.
+        return_fs : bool, default True
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
@@ -1100,7 +1103,9 @@ class SHHS(NSRRDataBase, PSGDataBaseMixin):
         elif data_format.lower() in ["channel_last", "lead_last"]:
             data = data[:, np.newaxis]
 
-        return data, data_fs
+        if return_fs:
+            return data, data_fs
+        return data
 
     @add_docstring(
         " " * 8 + "NOTE: one should call `load_psg_data` to load other channels.",
@@ -1116,7 +1121,8 @@ class SHHS(NSRRDataBase, PSGDataBaseMixin):
         data_format: str = "channel_first",
         units: Union[str, type(None)] = "mV",
         fs: Optional[int] = None,
-    ) -> Tuple[np.ndarray, Real]:
+        return_fs: bool = True,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         """alias of `load_ecg_data`"""
         return self.load_ecg_data(
             rec=rec,
@@ -1126,6 +1132,7 @@ class SHHS(NSRRDataBase, PSGDataBaseMixin):
             data_format=data_format,
             units=units,
             fs=fs,
+            return_fs=return_fs,
         )
 
     def load_ann(

--- a/torch_ecg/databases/other_databases/cachet_cadb.py
+++ b/torch_ecg/databases/other_databases/cachet_cadb.py
@@ -407,6 +407,7 @@ class CACHET_CADB(_DataBase):
             The loaded ECG data.
         data_fs : numbers.Real, optional
             Sampling frequency of the output signal.
+            Returned if `return_fs` is True.
 
         """
         if isinstance(rec, int):

--- a/torch_ecg/databases/other_databases/cachet_cadb.py
+++ b/torch_ecg/databases/other_databases/cachet_cadb.py
@@ -5,7 +5,7 @@ import warnings
 from copy import deepcopy
 from pathlib import Path
 import xml.etree.ElementTree as ET
-from typing import Any, Optional, Sequence, Dict, List, Union
+from typing import Any, Optional, Sequence, Dict, List, Union, Tuple
 from numbers import Real
 
 import numpy as np
@@ -372,7 +372,8 @@ class CACHET_CADB(_DataBase):
         data_format: str = "channel_first",
         units: Union[str, type(None)] = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         """Load physical (converted from digital) ECG data,
         or load digital signal directly.
 
@@ -397,11 +398,15 @@ class CACHET_CADB(_DataBase):
             Sampling frequency of the output signal.
             If not None, the loaded data will be resampled to this frequency,
             otherwise, the original sampling frequency will be used.
+        return_fs : bool, default False
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
         data : numpy.ndarray
             The loaded ECG data.
+        data_fs : numbers.Real, optional
+            Sampling frequency of the output signal.
 
         """
         if isinstance(rec, int):
@@ -437,7 +442,12 @@ class CACHET_CADB(_DataBase):
 
         if fs is not None and fs != self.fs:
             data = SS.resample_poly(data, fs, self.fs, axis=0).astype(data.dtype)
+            data_fs = fs
+        else:
+            data_fs = self.fs
 
+        if return_fs:
+            return data, data_fs
         return data
 
     def load_context_data(

--- a/torch_ecg/databases/other_databases/sph.py
+++ b/torch_ecg/databases/other_databases/sph.py
@@ -220,6 +220,7 @@ class SPH(_DataBase):
             The loaded ECG data.
         data_fs : numbers.Real, optional
             Sampling frequency of the output signal.
+            Returned if `return_fs` is True.
 
         """
         assert data_format.lower() in [

--- a/torch_ecg/databases/other_databases/sph.py
+++ b/torch_ecg/databases/other_databases/sph.py
@@ -194,6 +194,7 @@ class SPH(_DataBase):
         leads: Optional[Union[str, int, List[Union[str, int]]]] = None,
         data_format: str = "channel_first",
         units: str = "mV",
+        return_fs: bool = False,
     ) -> np.ndarray:
         """Load ECG data from h5 file of the record.
 
@@ -210,11 +211,15 @@ class SPH(_DataBase):
         units : str, default "mV"
             Units of the output signal,
             can also be "μV" (alias "uV", "muV").
+        return_fs : bool, default False
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
         data : numpy.ndarray
             The loaded ECG data.
+        data_fs : numbers.Real, optional
+            Sampling frequency of the output signal.
 
         """
         assert data_format.lower() in [
@@ -237,6 +242,8 @@ class SPH(_DataBase):
         if data_format.lower() in ["channel_last", "lead_last"]:
             data = data.T
 
+        if return_fs:
+            return data, self.fs
         return data
 
     def load_ann(

--- a/torch_ecg/databases/physionet_databases/apnea_ecg.py
+++ b/torch_ecg/databases/physionet_databases/apnea_ecg.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional, Union, Sequence, List
+from typing import Any, Optional, Union, Sequence, List, Tuple
 from numbers import Real
 
 import numpy as np
@@ -208,8 +208,11 @@ class ApneaECG(PhysioNetDataBase):
         data_format: str = "channel_first",
         units: Union[str, type(None)] = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
-        return super().load_data(rec, leads, sampfrom, sampto, data_format, units, fs)
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
+        return super().load_data(
+            rec, leads, sampfrom, sampto, data_format, units, fs, return_fs
+        )
 
     @add_docstring(PhysioNetDataBase.load_data.__doc__)
     def load_ecg_data(
@@ -220,7 +223,8 @@ class ApneaECG(PhysioNetDataBase):
         data_format: str = "channel_first",
         units: Union[str, type(None)] = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         if isinstance(rec, int):
             rec = self[rec]
         if rec not in self.ecg_records:
@@ -232,6 +236,7 @@ class ApneaECG(PhysioNetDataBase):
             data_format=data_format,
             units=units,
             fs=fs,
+            return_fs=return_fs,
         )
 
     @add_docstring(
@@ -249,6 +254,7 @@ class ApneaECG(PhysioNetDataBase):
         data_format: str = "channel_first",
         units: Union[str, type(None)] = "mV",
         fs: Optional[Real] = None,
+        return_fs: bool = False,
     ) -> np.ndarray:
         if rec not in self.rsp_records:
             raise ValueError(f"`{rec}` is not a record of RSP signals")
@@ -260,6 +266,7 @@ class ApneaECG(PhysioNetDataBase):
             data_format=data_format,
             units=units,
             fs=fs,
+            return_fs=return_fs,
         )
         return data
 

--- a/torch_ecg/databases/physionet_databases/cinc2018.py
+++ b/torch_ecg/databases/physionet_databases/cinc2018.py
@@ -466,6 +466,7 @@ class CINC2018(PhysioNetDataBase, PSGDataBaseMixin):
             with given `units` and `data_format`.
         data_fs : numbers.Real, optional
             Sampling frequency of the output signal.
+            Returned if `return_fs` is True.
 
         """
         available_signals = self.get_available_signals(rec)

--- a/torch_ecg/databases/physionet_databases/cinc2018.py
+++ b/torch_ecg/databases/physionet_databases/cinc2018.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from numbers import Real
 from pathlib import Path
-from typing import Any, Optional, Union, Sequence, List, Dict
+from typing import Any, Optional, Union, Sequence, List, Dict, Tuple
 
 import numpy as np
 import pandas as pd
@@ -326,7 +326,8 @@ class CINC2018(PhysioNetDataBase, PSGDataBaseMixin):
         data_format: str = "channel_first",
         physical: bool = True,
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         """Load PSG data of the record.
 
         Parameters
@@ -353,11 +354,15 @@ class CINC2018(PhysioNetDataBase, PSGDataBaseMixin):
             Sampling frequency of the output signal.
             If not None, the loaded data will be resampled to this frequency,
             otherwise, the original sampling frequency will be used.
+        return_fs : bool, default False
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
-        numpy.ndarray
+        data : numpy.ndarray
             PSG data corr. to the given `channel` of the record.
+        data_fs : numbers.Real, optional
+            Sampling frequency of the output signal.
 
         """
         available_signals = self.get_available_signals(rec)
@@ -403,12 +408,17 @@ class CINC2018(PhysioNetDataBase, PSGDataBaseMixin):
 
         if fs is not None and fs != wfdb_header.fs:
             ret_data = SS.resample_poly(ret_data, fs, wfdb_header.fs, axis=-1)
+            data_fs = fs
+        else:
+            data_fs = wfdb_header.fs
 
         if data_format.lower() in ["channel_last", "lead_last"]:
             ret_data = ret_data.T
         elif data_format.lower() in ["flat", "plain"]:
             ret_data = ret_data.flatten()
 
+        if return_fs:
+            return ret_data, data_fs
         return ret_data
 
     def load_data(
@@ -419,7 +429,8 @@ class CINC2018(PhysioNetDataBase, PSGDataBaseMixin):
         data_format: str = "channel_first",
         units: Union[str, type(None)] = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         """Load ECG data of the record.
 
         Parameters
@@ -445,12 +456,16 @@ class CINC2018(PhysioNetDataBase, PSGDataBaseMixin):
             Sampling frequency of the output signal.
             If not None, the loaded data will be resampled to this frequency,
             otherwise, the original sampling frequency will be used.
+        return_fs : bool, default False
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
-        numpy.ndarray
+        data : numpy.ndarray
             The ECG data loaded from the record,
             with given `units` and `data_format`.
+        data_fs : numbers.Real, optional
+            Sampling frequency of the output signal.
 
         """
         available_signals = self.get_available_signals(rec)
@@ -461,7 +476,7 @@ class CINC2018(PhysioNetDataBase, PSGDataBaseMixin):
         assert (
             units is None or units.lower() in allowed_units
         ), f"`units` should be one of `{allowed_units}` or None, but got `{units}`"
-        data = self.load_psg_data(
+        data, data_fs = self.load_psg_data(
             rec=rec,
             channel="ECG",
             sampfrom=sampfrom,
@@ -469,9 +484,13 @@ class CINC2018(PhysioNetDataBase, PSGDataBaseMixin):
             data_format=data_format,
             physical=units is not None,
             fs=fs,
+            return_fs=True,
         )
         if units.lower() in ["μv", "uv", "muv"]:
             data = 1000 * data
+
+        if return_fs:
+            return data, data_fs
         return data
 
     @add_docstring(load_data.__doc__)
@@ -483,7 +502,8 @@ class CINC2018(PhysioNetDataBase, PSGDataBaseMixin):
         data_format: str = "channel_first",
         units: Union[str, type(None)] = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         """alias of `load_data`"""
         return self.load_data(
             rec=rec,
@@ -492,6 +512,7 @@ class CINC2018(PhysioNetDataBase, PSGDataBaseMixin):
             data_format=data_format,
             units=units,
             fs=fs,
+            return_fs=return_fs,
         )
 
     def load_ann(

--- a/torch_ecg/databases/physionet_databases/cinc2020.py
+++ b/torch_ecg/databases/physionet_databases/cinc2020.py
@@ -578,6 +578,7 @@ class CINC2020(PhysioNetDataBase):
             The ECG data of the record.
         data_fs : numbers.Real, optional
             Sampling frequency of the output signal.
+            Returned if `return_fs` is True.
 
         """
         if isinstance(rec, int):

--- a/torch_ecg/databases/physionet_databases/cinc2020.py
+++ b/torch_ecg/databases/physionet_databases/cinc2020.py
@@ -544,9 +544,9 @@ class CINC2020(PhysioNetDataBase):
         backend: str = "wfdb",
         units: Union[str, type(None)] = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
-        """
-        Load physical (converted from digital) ECG data,
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
+        """Load physical (converted from digital) ECG data,
         which is more understandable for humans;
         or load digital signal directly.
 
@@ -569,11 +569,15 @@ class CINC2020(PhysioNetDataBase):
             Sampling frequency of the output signal.
             If not None, the loaded data will be resampled to this frequency,
             otherwise, the original sampling frequency will be used.
+        return_fs : bool, default False
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
-        numpy.ndarray
+        data : numpy.ndarray
             The ECG data of the record.
+        data_fs : numbers.Real, optional
+            Sampling frequency of the output signal.
 
         """
         if isinstance(rec, int):
@@ -630,10 +634,15 @@ class CINC2020(PhysioNetDataBase):
             data = SS.resample_poly(data, fs, self.fs[tranche], axis=1).astype(
                 data.dtype
             )
+            data_fs = fs
+        else:
+            data_fs = self.fs[tranche]
 
         if data_format.lower() in ["channel_last", "lead_last"]:
             data = data.T
 
+        if return_fs:
+            return data, data_fs
         return data
 
     def load_ann(

--- a/torch_ecg/databases/physionet_databases/cinc2021.py
+++ b/torch_ecg/databases/physionet_databases/cinc2021.py
@@ -719,7 +719,8 @@ class CINC2021(PhysioNetDataBase):
         backend: str = "wfdb",
         units: Union[str, type(None)] = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
         """Load physical (converted from digital) ECG data.
 
         Parameters
@@ -741,11 +742,15 @@ class CINC2021(PhysioNetDataBase):
             Sampling frequency of the output signal.
             If not None, the loaded data will be resampled to this frequency,
             otherwise, the original sampling frequency will be used.
+        return_fs : bool, default False
+            Whether to return the sampling frequency of the output signal.
 
         Returns
         -------
-        numpy.ndarray
+        data : numpy.ndarray
             The loaded ECG data.
+        data_fs : numbers.Real, optional
+            Sampling frequency of the output signal.
 
         """
         if isinstance(rec, int):
@@ -807,12 +812,17 @@ class CINC2021(PhysioNetDataBase):
         rec_fs = self.get_fs(rec, from_hea=True)
         if fs is not None and fs != rec_fs:
             data = SS.resample_poly(data, fs, rec_fs, axis=1).astype(data.dtype)
+            data_fs = fs
+        else:
+            data_fs = rec_fs
         # if fs is not None and fs != self.fs[tranche]:
         #     data = SS.resample_poly(data, fs, self.fs[tranche], axis=1)
 
         if data_format.lower() in ["channel_last", "lead_last"]:
             data = data.T
 
+        if return_fs:
+            return data, data_fs
         return data
 
     def load_ann(

--- a/torch_ecg/databases/physionet_databases/cinc2021.py
+++ b/torch_ecg/databases/physionet_databases/cinc2021.py
@@ -751,6 +751,7 @@ class CINC2021(PhysioNetDataBase):
             The loaded ECG data.
         data_fs : numbers.Real, optional
             Sampling frequency of the output signal.
+            Returned if `return_fs` is True.
 
         """
         if isinstance(rec, int):

--- a/torch_ecg/databases/physionet_databases/ltafdb.py
+++ b/torch_ecg/databases/physionet_databases/ltafdb.py
@@ -5,7 +5,7 @@ import math
 from copy import deepcopy
 from numbers import Real
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union, Tuple
 
 import numpy as np
 import wfdb
@@ -164,8 +164,11 @@ class LTAFDB(PhysioNetDataBase):
         data_format: str = "channel_first",
         units: str = "mV",
         fs: Optional[Real] = None,
-    ) -> np.ndarray:
-        return super().load_data(rec, leads, sampfrom, sampto, data_format, units, fs)
+        return_fs: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, Real]]:
+        return super().load_data(
+            rec, leads, sampfrom, sampto, data_format, units, fs, return_fs
+        )
 
     def load_ann(
         self,


### PR DESCRIPTION
An optional argument `return_fs` is added to the method `load_data`, by setting which to be True, the returned valued of `load_data` has signature
```
Tuple[np.ndarray, Real]
```
and the elements of the tuple are
```
data : numpy.ndarray
    The ECG data loaded from the record,
    with given `units` and `data_format`.
data_fs : numbers.Real, optional
    Sampling frequency of the output signal.
```

The default value for `return_fs` is `False`, so that the default behaviour of `load_data` is unchanged.